### PR TITLE
Use hack-indent-offset for on-type-formatting in hack mode

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5480,6 +5480,7 @@ Request codeAction/resolve for more info if server supports."
     (powershell-mode    . powershell-indent)         ; PowerShell
     (ess-mode           . ess-indent-offset)         ; ESS (R)
     (yaml-mode          . yaml-indent-offset)        ; YAML
+    (hack-mode          . hack-indent-offset)        ; Hack
 
     (default            . standard-indent))          ; default fallback
   "A mapping from `major-mode' to its indent variable.")


### PR DESCRIPTION
Previously for lsp--get-indent-width was falling back to "default" case for hack-mode, resulting in inconsistent formatting (hack mode defaults to 2 spaces, default is 4).

Add hack-mode case using correct hack-indent-offset.